### PR TITLE
Fix: origEnv and persistend codepush config

### DIFF
--- a/templates/default/components/ErrorBoundaryFallback/ErrorBoundaryFallback.tsx
+++ b/templates/default/components/ErrorBoundaryFallback/ErrorBoundaryFallback.tsx
@@ -4,7 +4,6 @@ import React, {useEffect, useState} from "react";
 import {DevSettings, Pressable, Text, View} from "react-native";
 import {getBuildNumber, getVersion} from "react-native-device-info";
 import styles from "./ErrorBoundaryFallback.styles";
-
 interface Props {
   error: Error;
   clearAsyncStorageOnError?: boolean;
@@ -21,6 +20,7 @@ const ErrorBoundaryFallback: React.FC<Props> = ({error, clearAsyncStorageOnError
     } catch (err) {
       console.log("Could not clear async storage", err);
     } finally {
+      // FIXME: This will crash when not in DEV mode!
       DevSettings.reload();
     }
   }

--- a/templates/default/components/ErrorBoundaryFallback/ErrorBoundaryFallback.tsx
+++ b/templates/default/components/ErrorBoundaryFallback/ErrorBoundaryFallback.tsx
@@ -1,11 +1,11 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import {t} from "i18n-js";
 import React, {useEffect, useState} from "react";
-import {DevSettings, Pressable, PressableProps, Text, View} from "react-native";
+import {DevSettings, Pressable, Text, View} from "react-native";
 import {getBuildNumber, getVersion} from "react-native-device-info";
 import styles from "./ErrorBoundaryFallback.styles";
 
-interface Props extends PressableProps {
+interface Props {
   error: Error;
   clearAsyncStorageOnError?: boolean;
 }

--- a/templates/default/config/config.ts
+++ b/templates/default/config/config.ts
@@ -6,11 +6,6 @@ export type ConfigEnv = typeof envs[number];
 const configByEnv = {
   // Config applied to all envs
   global: {
-    codePush: {
-      // Set to true if app will use CodePush
-      enabled: false,
-    },
-
     devSettings: {
       // Optionally protect dev settings behind a pin code
       // will be default be disabled in __DEV__ mode
@@ -65,7 +60,26 @@ export function setSelectedEnv(selectedEnvOverride: ConfigEnv) {
   selectedEnv = selectedEnvOverride;
 }
 
-export function config(_selectedEnv?: ConfigEnv) {
-  const envConfig = selectedEnv ? configByEnv[selectedEnv] : configByEnv[env as ConfigEnv];
-  return {...configByEnv.global, ...envConfig};
+export function config() {
+  const origEnv = env as ConfigEnv;
+  const origConfig = configByEnv[origEnv];
+  const envConfig = selectedEnv ? configByEnv[selectedEnv] : origConfig;
+  return {
+    ...configByEnv.global,
+    ...envConfig,
+    /**
+     * Currently selected environment
+     */
+    env: selectedEnv,
+    /**
+     * Original environment for app, not taking any
+     * into account
+     */
+    origEnv,
+    /**
+     * CodePush configuration, note that CodePush config remains
+     * the same even though env is switched in runtime.
+     */
+    codePush: origConfig.codePush,
+  };
 }


### PR DESCRIPTION
* Adds `env` and `origEnv` to config
* Makes sure that code push config is same and does not change when env override is set